### PR TITLE
Set up Lab test suite

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "lab -T node_modules/lab-babel test/index.js",
     "start": "nodemon ./server.js --exec babel-node"
   },
   "repository": {
@@ -40,6 +40,9 @@
     "chai": "^3.5.0",
     "eslint": "^3.15.0",
     "eslint-plugin-import": "^2.2.0",
+    "lab": "^12.1.0",
+    "lab-babel": "^1.1.1",
+    "labbable": "^2.1.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
     "sinon": "^1.17.7"

--- a/src/server.js
+++ b/src/server.js
@@ -2,16 +2,28 @@ import Glue from 'glue';
 import manifest from './manifest.json';
 import env from 'dotenv';
 env.config();
+import Labbable from 'labbable';
+
+export const labbable = new Labbable();
 
 Glue.compose(manifest, { relativeTo: __dirname }, (err, server) => {
-  server.start((err) => {
+  labbable.using(server);
+  server.initialize((err) => {
     if (err) {
       throw err;
-    } else {
-      /* eslint-disable no-console */
-      console.log('Server has started...');
-      /* eslint-enable no-console */
     }
+    if (module.parent) {
+      return;
+    }
+    server.start((err) => {
+      if (err) {
+        throw err;
+      } else {
+        /* eslint-disable no-console */
+        console.log('Server has started...');
+        /* eslint-enable no-console */
+      }
+    });
   });
 });
 

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,0 +1,44 @@
+import Lab from 'lab';
+import { expect } from 'chai';
+import { labbable } from '../server.js';
+
+const lab = exports.lab = Lab.script();
+
+lab.experiment('API', () => {
+
+  let server;
+
+  lab.before((done) => {
+    labbable.ready((err, srv) => {
+      if (err) {
+        return done(err);
+      }
+      server = srv;
+      return done();
+    });
+  });
+
+  lab.describe('User API', () => {
+
+    let createUserRequest;
+
+    lab.before((done) => {
+      createUserRequest = {
+        method: 'POST',
+        url: '/api/user',
+        payload: {
+          phoneNumber: '4805551234'
+        }
+      };
+      done();
+    });
+
+    lab.test('It creates a user', (done) => {
+      server.select('api').inject(createUserRequest, (res) => {
+        expect(res.statusCode).to.equal(201);
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
- Add a [lab](https://github.com/hapijs/lab) test suite. (Run tests with `npm test`).
- Add `lab` (test framework), [`lab-babel`](https://github.com/nlf/lab-babel) (for transpiling lab tests with Babel), and [`labbable`](https://github.com/devinivy/labbable) (for running server tests).
- Refactor `src/server.js` to work with labbable.
- Add a working test in `src/test/index.js`