### PR TITLE
Add Raid schema/model

### DIFF
--- a/src/app/shared/models/raid.js
+++ b/src/app/shared/models/raid.js
@@ -1,0 +1,34 @@
+import mongoose, { Schema } from 'mongoose';
+
+const validateExactlyTwoCoordinates = (coordinates) => {
+  return coordinates.length === 2;
+};
+
+export const raidSchema = new Schema({
+  date: {
+    type: Date,
+    required: true
+  },
+  description: String,
+  location: {
+    type: [Number],
+    required: true,
+    index: '2d',
+    validate: {
+      validator: validateExactlyTwoCoordinates,
+      message: 'Location requires both latitude and longitude!'
+    }
+  },
+  type: {
+    type: String,
+    required: true,
+    enum: ['workplace', 'home']
+  },
+  verified: {
+    type: Boolean,
+    required: true,
+    default: false
+  }
+});
+
+export default mongoose.model('Raid', raidSchema);

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "lab -T node_modules/lab-babel test/index.js",
+    "test": "lab -T node_modules/lab-babel test",
     "start": "nodemon ./server.js --exec babel-node"
   },
   "repository": {

--- a/src/test/shared/models/test_raid.js
+++ b/src/test/shared/models/test_raid.js
@@ -1,0 +1,129 @@
+import Lab from 'lab';
+import { expect } from 'chai';
+import Raid from '../../../app/shared/models/raid';
+
+const lab = exports.lab = Lab.script();
+
+lab.experiment('Raid model', () => {
+
+  lab.test('It has a description', (done) => {
+    let raid = Raid({
+      description: 'Some description'
+    });
+    expect(raid.description).to.eq('Some description');
+    done();
+  });
+
+  lab.test('It has a date', (done) => {
+    let now = new Date();
+    let raid = Raid({
+      date: now
+    });
+    expect(raid.date).to.eq(now);
+    done();
+  });
+
+  lab.test('It requires a date', (done) => {
+    let raid = Raid();
+    raid.validate((err) => {
+      expect(err.errors.date).to.exist;
+      done();
+    });
+  });
+
+  lab.test('It has a location', (done) => {
+    let longitude = -112.097008;
+    let latitude = 33.448304;
+    let raid = Raid({
+      location: [longitude, latitude]
+    });
+    expect(raid.location[0]).to.eq(longitude);
+    expect(raid.location[1]).to.eq(latitude);
+    done();
+  });
+
+  lab.test('It requires a location', (done) => {
+    let raid = Raid();
+    raid.validate((err) => {
+      expect(err.errors.location).to.exist;
+      done();
+    });
+  });
+
+  lab.test('Location requires both lon and lat', (done) => {
+    let longitude = -112.097008;
+    let raid = Raid({
+      location: [longitude]
+    });
+    raid.validate((err) => {
+      expect(err.errors.location).to.exist;
+      done();
+    });
+  });
+
+  lab.test('Location requires exactly two coordinates', (done) => {
+    let longitude = -112.097008;
+    let latitude = 33.448304;
+    let raid = Raid({
+      location: [longitude, latitude, latitude]
+    });
+    raid.validate((err) => {
+      expect(err.errors.location).to.exist;
+      done();
+    });
+  });
+
+  lab.test('It is unverified by default', (done) => {
+    let raid = Raid();
+    expect(raid.verified).to.be.false;
+    done();
+  });
+
+  lab.test('It can be verified', (done) => {
+    let raid = Raid({
+      verified: true
+     });
+    expect(raid.verified).to.be.true;
+    done();
+  });
+
+  lab.test('It requires verified', (done) => {
+    let raid = Raid();
+    raid.verified = undefined;
+    raid.validate((err) => {
+      expect(err.errors.verified).to.exist;
+      done();
+    });
+  });
+
+  lab.test('It has a type', (done) => {
+    let homeRaid = Raid({
+      type: 'home'
+    });
+    expect(homeRaid.type).to.eq('home');
+
+    let workplaceRaid = Raid({
+      type: 'workplace'
+    });
+    expect(workplaceRaid.type).to.eq('workplace');
+    done();
+  });
+
+  lab.test('It validates type', (done) => {
+    let raid = Raid({
+      type: 'this is not a valid type'
+    });
+    raid.validate((err) => {
+      expect(err.errors.type).to.exist;
+      done();
+    });
+  });
+
+  lab.test('It requires a type', (done) => {
+    let raid = Raid();
+    raid.validate((err) => {
+      expect(err.errors.type).to.exist;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Add `Raid` schema/model with tests.

Required fields:
- Date (a JS `Date`)
- Location (a `[longitude, latitude]` pair. This is a [simple way](https://docs.mongodb.com/manual/core/2d/) to store location data in Mongo, although [GeoJSON](https://docs.mongodb.com/manual/reference/geojson/) might be better. Note that Mongo wants longitude first, which is unusual!)
- Type (a `String` with enumerated options. I added `'workplace'` and `'home'` to start.
- Verified (`Boolean`, defaults to `false`)

Optional fields:
-  Description (a `String`)