### PR TITLE
Extend RaidStore

### DIFF
--- a/src/app/api/stores/raidStore.js
+++ b/src/app/api/stores/raidStore.js
@@ -9,6 +9,14 @@ const raidStore = {
       type: payload.type,
     });
   },
+  getRaid(payload) {
+    return Raid.findOne({
+      _id: payload._id
+    });
+  },
+  getRaids() {
+    return Raid.find({});
+  }
 };
 
 export default raidStore;

--- a/src/app/shared/models/raid.js
+++ b/src/app/shared/models/raid.js
@@ -6,7 +6,11 @@ export const raidSchema = new Schema({
     required: true,
   },
   description: String,
-  location: [Number],
+  location: {
+    type: [Number],
+    required: true,
+    index: '2d'
+  },
   type: {
     type: String,
     required: true,

--- a/src/app/shared/plugins/db.js
+++ b/src/app/shared/plugins/db.js
@@ -1,9 +1,18 @@
 import mongoose from 'mongoose';
 import bluebird from 'bluebird';
 
+const getDBConnectionString = () => {
+  const defaultConnectionString = process.env.MONGO_URI;
+  if (process.env.NODE_ENV === 'test') {
+    return `${defaultConnectionString}_test`;
+  } else {
+    return defaultConnectionString
+  }
+};
+
 export const register = (server, options, next) => {
   mongoose.Promise = bluebird;
-  mongoose.connect(process.env.MONGO_URI);
+  mongoose.connect(getDBConnectionString());
   next();
 };
 

--- a/src/test/api/routes/raids/test_config.js
+++ b/src/test/api/routes/raids/test_config.js
@@ -1,0 +1,38 @@
+import Lab from 'lab';
+import Joi from 'joi';
+import { expect } from 'chai';
+import { raid } from '../../../../app/api/routes/raids/config';
+
+const lab = exports.lab = Lab.script();
+
+lab.experiment('Raid validation', () => {
+
+  lab.test('Location requires both lon and lat', (done) => {
+    let data = {
+      date: new Date(),
+      description: 'Some description',
+      location: [-112.097008],
+      type: 'workplace'
+    };
+    Joi.validate(data, raid.validate.payload, (err, value) => {
+      let errorMessage = err.details[0].message;
+      expect(errorMessage).to.eql('"location" must contain at least 2 items');
+      done();
+    });
+  });
+
+  lab.test('Location requires exactly two coordinates', (done) => {
+    let data = {
+      date: new Date(),
+      description: 'Some description',
+      location: [-112.097008, 33.448304, 55.643201],
+      type: 'workplace'
+    };
+    Joi.validate(data, raid.validate.payload, (err, value) => {
+      let errorMessage = err.details[0].message;
+      expect(errorMessage).to.eql('"location" must contain less than or equal to 2 items');
+      done();
+    });
+  });
+
+});

--- a/src/test/api/stores/test_raid_store.js
+++ b/src/test/api/stores/test_raid_store.js
@@ -1,0 +1,103 @@
+import Lab from 'lab';
+import { expect } from 'chai';
+import RaidStore from '../../../app/api/stores/raidStore';
+import Raid from '../../../app/shared/models/raid';
+
+const lab = exports.lab = Lab.script();
+
+lab.experiment('Raid store', () => {
+
+  lab.before((done) => {
+    Raid.remove({}, done);
+  });
+
+  lab.afterEach((done) => {
+    Raid.remove({}, done);
+  });
+
+  lab.describe('Create', () => {
+
+    lab.test('It creates a raid', (done) => {
+      let payload = {
+        date: new Date(),
+        location: [-112.097008, 33.448304],
+        type: 'workplace'
+      };
+      RaidStore.createRaid(payload).then((raid) => {
+        expect(raid).not.to.be.null;
+        done();
+      });
+    });
+
+    lab.test('It is unverified by default', (done) => {
+      let payload = {
+        date: new Date(),
+        location: [-112.097008, 33.448304],
+        type: 'workplace'
+      };
+      RaidStore.createRaid(payload).then((raid) => {
+        expect(raid.verified).to.be.false;
+        done();
+      });
+    });
+
+    lab.test('It handles descriptions', (done) => {
+      let payload = {
+        date: new Date(),
+        description: 'Some description',
+        location: [-112.097008, 33.448304],
+        type: 'workplace'
+      };
+      RaidStore.createRaid(payload).then((raid) => {
+        expect(raid.description).to.eql('Some description');
+        done();
+      });
+    });
+  });
+
+  lab.describe('Read', () => {
+
+    lab.test('It reads a raid', (done) => {
+      let payload = {
+        date: new Date(),
+        location: [-112.097008, 33.448304],
+        type: 'workplace'
+      };
+      RaidStore.createRaid(payload).then((createdRaid) => {
+        RaidStore.getRaid({_id: createdRaid._id}).then((readRaid) => {
+          expect(readRaid._id).to.eql(createdRaid._id);
+          expect(readRaid.date).to.eql(createdRaid.date);
+          expect(readRaid.location[0]).to.eql(createdRaid.location[0]);
+          expect(readRaid.location[1]).to.eql(createdRaid.location[1]);
+          expect(readRaid.type).to.eql(createdRaid.type);
+          expect(readRaid.verified).to.eql(createdRaid.verified);
+          done();
+        });
+      });
+    });
+  });
+
+  lab.describe('Read all', () => {
+
+    lab.test('It reads all raids', (done) => {
+      let workplace = {
+        date: new Date(),
+        location: [-112.097008, 33.448304],
+        type: 'workplace'
+      };
+      let home = {
+        date: new Date(),
+        location: [-112.097008, 33.448304],
+        type: 'home'
+      };
+      RaidStore.createRaid(workplace).then(() => {
+        RaidStore.createRaid(home).then(() => {
+          RaidStore.getRaids().then((raids) => {
+            expect(raids.length).to.eql(2);
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/test/shared/models/test_raid.js
+++ b/src/test/shared/models/test_raid.js
@@ -50,29 +50,6 @@ lab.experiment('Raid model', () => {
     });
   });
 
-  lab.test('Location requires both lon and lat', (done) => {
-    let longitude = -112.097008;
-    let raid = Raid({
-      location: [longitude]
-    });
-    raid.validate((err) => {
-      expect(err.errors.location).to.exist;
-      done();
-    });
-  });
-
-  lab.test('Location requires exactly two coordinates', (done) => {
-    let longitude = -112.097008;
-    let latitude = 33.448304;
-    let raid = Raid({
-      location: [longitude, latitude, latitude]
-    });
-    raid.validate((err) => {
-      expect(err.errors.location).to.exist;
-      done();
-    });
-  });
-
   lab.test('It is unverified by default', (done) => {
     let raid = Raid();
     expect(raid.verified).to.be.false;


### PR DESCRIPTION
- Add getRaid to get raids by ID.
- Add getRaids to list all raids.
- Move validation tests to test/api/routes/raids/test_config.js
- Append `_test` to default DB name if `NODE_ENV` equals `'test'`

Test frameworks usually have a convention for clearing out the test DB before every test, so they run in isolation. I'm not sure how best to implement that with hapi/lab. I did my best [here](https://github.com/Cosecha/redadalertas-api/compare/master...ecmendenhall:raid-store?expand=1#diff-11d92f5a430edf9bb0ef76e4810f922bR10), but there's probably a better way!